### PR TITLE
More tolerance for path to room id

### DIFF
--- a/src/mattermost.coffee
+++ b/src/mattermost.coffee
@@ -10,7 +10,7 @@ class Mattermost extends Adapter
     for str in strings
       data = JSON.stringify({
         icon_url: @icon,
-        channel: @channel ? envelope.user.room, # send back to source channel only if not overwritten,
+        channel: @channel ? envelope.user?.room ? envelope.room, # send back to source channel only if not overwritten,
         username: @username,
         text: str
       })


### PR DESCRIPTION
Some scripts e.g. hubot-rss-reader are using different paths to define `room`. This adds support for `envelope.room`.
