### PR TITLE
Use same username to respond and send messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In addition, the following optional variables can be set:
 
 * `MATTERMOST_CHANNEL` _string, default: none_ - Override the channel that you want to reply to.
 * `MATTERMOST_ICON_URL` _string, default: none_ - If Enable Overriding of Icon from Webhooks is enabled you can set a url with the icon that you want for your hubot.
-* `MATTERMOST_HUBOT_USERNAME` _string, default: none_ - If Enable Overriding of Usernames from Webhooks you can set a custom username to show in mattermost.
+* `MATTERMOST_HUBOT_USERNAME` _string, default: Hubot's name_ - You can set a custom username to respond in mattermost. If Enable Overriding of Usernames from Webhooks, this name is shown in mattermost.
 * `MATTERMOST_SELFSIGNED_CERT` _boolean, default: none_ - If true it will ignore if MATTERMOST_ENDPOINT has a self signed certificate.
 
 ## Example for Environment variables

--- a/src/mattermost.coffee
+++ b/src/mattermost.coffee
@@ -11,7 +11,7 @@ class Mattermost extends Adapter
       data = JSON.stringify({
         icon_url: @icon,
         channel: @channel ? envelope.user?.room ? envelope.room, # send back to source channel only if not overwritten,
-        username: @username,
+        username: @robot.name,
         text: str
       })
       @robot.http(@url)
@@ -35,7 +35,8 @@ class Mattermost extends Adapter
     @endpoint = process.env.MATTERMOST_ENDPOINT
     @url = process.env.MATTERMOST_INCOME_URL 
     @icon = process.env.MATTERMOST_ICON_URL 
-    @username = process.env.MATTERMOST_HUBOT_USERNAME
+    if process.env.MATTERMOST_HUBOT_USERNAME?
+      @robot.name = process.env.MATTERMOST_HUBOT_USERNAME
     @selfsigned = this.getBool(process.env.MATTERMOST_SELFSIGNED_CERT) if process.env.MATTERMOST_SELFSIGNED_CERT
     if @selfsigned then process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
     unless @tokens?


### PR DESCRIPTION
When `MATTERMOST_HUBOT_USERNAME` isn't set, use Hubot's name (set by `yo hubot` ot `--name` option) as default.
In previous implementation, Hubot responds to its name even if `MATTERMOST_HUBOT_USERNAME` is set. It's confusing because different names are used.
