### PR TITLE
Add support for slash commands

### DIFF
--- a/src/mattermost.coffee
+++ b/src/mattermost.coffee
@@ -53,6 +53,9 @@ class Mattermost extends Adapter
      for token in @tokens.split(',')     
        if token is req.body.token
          msg = req.body.text
+         # support for slash commands
+         if req.body.command?
+            msg = req.body.command + ' ' + msg
          user = @robot.brain.userForId(req.body.user_id)
          user.name = req.body.user_name
          user.room = req.body.channel_name

--- a/src/mattermost.coffee
+++ b/src/mattermost.coffee
@@ -55,7 +55,7 @@ class Mattermost extends Adapter
          msg = req.body.text
          # support for slash commands
          if req.body.command?
-            msg = req.body.command + ' ' + msg
+            msg = req.body.command.replace(/^\//,'') + ' ' + msg
          user = @robot.brain.userForId(req.body.user_id)
          user.name = req.body.user_name
          user.room = req.body.channel_name

--- a/src/mattermost.coffee
+++ b/src/mattermost.coffee
@@ -60,8 +60,8 @@ class Mattermost extends Adapter
          user.name = req.body.user_name
          user.room = req.body.channel_name
          @robot.receive new TextMessage(user, msg)
-         res.writeHead 200, 'Content-Type': 'text/plain'
-         res.end()
+         res.writeHead 200, 'Content-Type': 'application/json'
+         res.end('{}')
 
   getBool: (val) ->
     return !!JSON.parse(String(val).toLowerCase());


### PR DESCRIPTION
This adds support for slash commands by sending the name of the command to hubot (therefor the command name should match the hubot's `--name`). To use, add a Slash command in Mattermost and add the command's token to `MATTERMOST_TOKEN` just like a regular webhook.